### PR TITLE
feat: change attestation justification from bytes32 to bytes for unli…

### DIFF
--- a/frontend/src/hooks/attestations/use-create-attestation.ts
+++ b/frontend/src/hooks/attestations/use-create-attestation.ts
@@ -69,7 +69,7 @@ export function useCreateAttestation() {
         );
       }
       isBusyRef.current = true;
-      // Convert strings to bytes32
+      // Convert strings to bytes
       const badgeNameBytes = stringToBytes32(badgeName);
       const justificationBytes = stringToBytes(justification);
 

--- a/the-guild-smart-contracts/INTEGRATION.md
+++ b/the-guild-smart-contracts/INTEGRATION.md
@@ -2,7 +2,7 @@
 
 This guide shows how to create on-chain attestations of TheGuild badges from a frontend using the EAS SDK, following the schema described in `README.md`.
 
-- Schema: `bytes32 badgeName, bytes32 justification`
+- Schema: `bytes32 badgeName, bytes justification`
 - Hardcoded schema id for now: set `SCHEMA_ID` to a placeholder and replace later
 
 References:
@@ -34,7 +34,7 @@ export const SCHEMA_ID =
 import { SchemaEncoder } from '@ethereum-attestation-service/eas-sdk';
 
 export const schemaEncoder = new SchemaEncoder(
-  'bytes32 badgeName, bytes32 justification'
+  'bytes32 badgeName, bytes justification'
 );
 
 export function encodeBadgeData(
@@ -43,7 +43,7 @@ export function encodeBadgeData(
 ) {
   return schemaEncoder.encodeData([
     { name: 'badgeName', value: badgeName, type: 'bytes32' },
-    { name: 'justification', value: justification, type: 'bytes32' },
+    { name: 'justification', value: justification, type: 'bytes' },
   ]);
 }
 ```
@@ -198,8 +198,8 @@ export async function getAttestation(uid: `0x${string}`) {
 ## Tips
 
 - Replace `SCHEMA_ID` with the actual schema id you register in EAS.
-- Keep the schema definition exactly as specified: `bytes32 badgeName, bytes32 justification`.
-- If you prefer using viem’s clients directly, you can still obtain an `ethers` Signer (as shown) solely for interacting with EAS SDK per its docs.
+- Keep the schema definition exactly as specified: `bytes32 badgeName, bytes justification`.
+- If you prefer using viem's clients directly, you can still obtain an `ethers` Signer (as shown) solely for interacting with EAS SDK per its docs.
 
 Links: [EAS SDK attestations](https://docs.attest.org/docs/developer-tools/eas-sdk#creating-onchain-attestations), [EAS + wagmi](https://docs.attest.org/docs/developer-tools/sdk-wagmi)
 

--- a/the-guild-smart-contracts/README.md
+++ b/the-guild-smart-contracts/README.md
@@ -13,7 +13,7 @@ Community members can vote on badge relevancy to filter spam and promote the mos
 ### Attestations
 Then, we let users create an attestation of a badge to another user. The attestation can contain an optional justification (link to a project, or text explanation).
 
-To do this, we can just use EAS' already deployed contracts. First we will register our schema (using their sdk or their UI): "bytes32 badgeName, bytes32 justification". Then, in the front end, we can use their sdk to create attestation from one user to another, referencing our schema id, the unique badge name, and a justification. We can also use EAS Resolver contract to prevent duplicate badges and reward attestations with Activity Token.
+To do this, we can just use EAS' already deployed contracts. First we will register our schema (using their sdk or their UI): "bytes32 badgeName, bytes justification". Then, in the front end, we can use their sdk to create attestation from one user to another, referencing our schema id, the unique badge name, and a justification. We can also use EAS Resolver contract to prevent duplicate badges and reward attestations with Activity Token.
 
 ### Integration
 For detailed frontend integration instructions, see [INTEGRATION.md](./INTEGRATION.md).


### PR DESCRIPTION
Fixes #33 

Change EAS schema justification field from bytes32 (32 byte limit) to bytes (unlimited). 
Update encoding/decoding logic in frontend hooks and documentation accordingly.