### PR TITLE
feat: add plus button to badges for quick attestation (#52)

### DIFF
--- a/frontend/src/components/profiles/action-buttons/AddAttestationDialog.tsx
+++ b/frontend/src/components/profiles/action-buttons/AddAttestationDialog.tsx
@@ -43,9 +43,11 @@ type FormValues = z.infer<typeof formSchema>;
 export function AddAttestationDialog({
   recipient,
   children,
+  preselectedBadge,
 }: {
   recipient: string;
   children: React.ReactElement;
+  preselectedBadge?: string;
 }) {
   const [open, setOpen] = useState(false);
   const [errorDisplayText, setErrorDisplayText] = useState<string | null>(null);
@@ -63,7 +65,7 @@ export function AddAttestationDialog({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
-    defaultValues: { badgeName: "", justification: "" },
+    defaultValues: { badgeName: preselectedBadge || "", justification: "" },
   });
 
   const onSubmit = async (values: FormValues) => {
@@ -106,6 +108,12 @@ export function AddAttestationDialog({
     form,
     reset,
   ]);
+
+  useEffect(() => {
+    if (open && preselectedBadge) {
+      form.setValue("badgeName", preselectedBadge);
+    }
+  }, [open, preselectedBadge, form]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/frontend/src/components/profiles/profile-page/ProfileAttestations.tsx
+++ b/frontend/src/components/profiles/profile-page/ProfileAttestations.tsx
@@ -1,4 +1,4 @@
-import { Award, Badge } from "lucide-react";
+import { Award, Badge, Plus } from "lucide-react";
 import { useGetAttestations } from "@/hooks/attestations/use-get-attestations";
 import { useMemo } from "react";
 import {
@@ -9,10 +9,18 @@ import {
 } from "@/components/ui/accordion";
 import { useGetProfiles } from "@/hooks/profiles/use-get-profiles";
 import CopyAddressToClipboard from "@/components/CopyAddressToClipboard";
+import { AddAttestationDialog } from "@/components/profiles/action-buttons/AddAttestationDialog";
+import { Button } from "@/components/ui/button";
+import { useAccount } from "wagmi";
 
 export function ProfileAttestations({ address }: { address: string }) {
   const attestationsQuery = useGetAttestations();
   const profilesQuery = useGetProfiles();
+  const { address: connectedAddress } = useAccount();
+  const isOwner =
+    !!connectedAddress &&
+    !!address &&
+    connectedAddress.toLowerCase() === address.toLowerCase();
 
   const attestations = useMemo(() => {
     const list = attestationsQuery.data ?? [];
@@ -74,6 +82,24 @@ export function ProfileAttestations({ address }: { address: string }) {
                   <span className="text-sm text-gray-600">
                     ({items.length})
                   </span>
+                  {!isOwner && connectedAddress && badgeName && (
+                    <AddAttestationDialog
+                      recipient={address}
+                      preselectedBadge={badgeName}
+                    >
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0 ml-2"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                        }}
+                        aria-label="Add attestation for this badge"
+                      >
+                        <Plus className="h-3 w-3" />
+                      </Button>
+                    </AddAttestationDialog>
+                  )}
                 </div>
               </AccordionTrigger>
               <AccordionContent>

--- a/frontend/src/components/profiles/profile-page/ProfileIssuedAttestations.tsx
+++ b/frontend/src/components/profiles/profile-page/ProfileIssuedAttestations.tsx
@@ -1,4 +1,4 @@
-import { Send, Badge } from "lucide-react";
+import { Send, Badge, Plus } from "lucide-react";
 import { useGetAttestations } from "@/hooks/attestations/use-get-attestations";
 import { useMemo } from "react";
 import {
@@ -8,10 +8,18 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { useGetProfiles } from "@/hooks/profiles/use-get-profiles";
+import { AddAttestationDialog } from "@/components/profiles/action-buttons/AddAttestationDialog";
+import { Button } from "@/components/ui/button";
+import { useAccount } from "wagmi";
 
 export function ProfileIssuedAttestations({ address }: { address: string }) {
   const attestationsQuery = useGetAttestations();
   const profilesQuery = useGetProfiles();
+  const { address: connectedAddress } = useAccount();
+  const isOwner =
+    !!connectedAddress &&
+    !!address &&
+    connectedAddress.toLowerCase() === address.toLowerCase();
 
   const issuedAttestations = useMemo(() => {
     const list = attestationsQuery.data ?? [];
@@ -74,6 +82,24 @@ export function ProfileIssuedAttestations({ address }: { address: string }) {
                   <span className="text-sm text-gray-600">
                     ({items.length})
                   </span>
+                  {!isOwner && connectedAddress && badgeName && (
+                    <AddAttestationDialog
+                      recipient={address}
+                      preselectedBadge={badgeName}
+                    >
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0 ml-2"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                        }}
+                        aria-label="Add attestation for this badge"
+                      >
+                        <Plus className="h-3 w-3" />
+                      </Button>
+                    </AddAttestationDialog>
+                  )}
                 </div>
               </AccordionTrigger>
               <AccordionContent>


### PR DESCRIPTION
## Add plus button to badges for quick attestation

Closes #52

### Summary
Adds a plus button next to each badge on profile pages that opens the attestation dialog with that badge preselected.

### Changes
- Added `preselectedBadge` prop to `AddAttestationDialog` component
- Added plus button next to badges in Attestations and Issued Attestations sections
- Button only visible to authenticated users viewing other profiles
- Click opens dialog with badge preselected

### Testing
- Plus button appears on other users' profiles when logged in
- Opens attestation dialog with correct badge selected
- Hidden on own profile and when not authenticated
- No TypeScript errors