### PR TITLE
Add project likes backend endpoints

### DIFF
--- a/backend/migrations/006_create_project_likes_table.sql
+++ b/backend/migrations/006_create_project_likes_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS project_likes (
+    project_id UUID NOT NULL,
+    user_address VARCHAR(42) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (project_id, user_address),
+    CONSTRAINT fk_project_likes_project FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_likes_project_id ON project_likes(project_id);
+CREATE INDEX IF NOT EXISTS idx_project_likes_user_address ON project_likes(user_address);

--- a/backend/src/application/commands/create_project_like.rs
+++ b/backend/src/application/commands/create_project_like.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use crate::{
+    application::dtos::like_dtos::ProjectLikeCreatedResponse,
+    domain::{
+        entities::projects::ProjectId,
+        repositories::{ProjectLikeRepository, ProjectRepository},
+        value_objects::WalletAddress,
+    },
+};
+
+pub async fn create_project_like(
+    project_repository: Arc<dyn ProjectRepository>,
+    like_repository: Arc<dyn ProjectLikeRepository>,
+    user_address: String,
+    project_id: String,
+) -> Result<ProjectLikeCreatedResponse, String> {
+    let user_address = WalletAddress::new(user_address.to_lowercase())
+        .map_err(|e| format!("Invalid wallet address: {}", e))?;
+
+    let uuid = uuid::Uuid::parse_str(&project_id).map_err(|_| "Invalid project id".to_string())?;
+    let project_id = ProjectId::from_uuid(uuid);
+
+    let exists = project_repository
+        .exists(&project_id)
+        .await
+        .map_err(|e| e.to_string())?;
+    if !exists {
+        return Err("Project not found".to_string());
+    }
+
+    let created = like_repository
+        .create(&project_id, &user_address)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if !created {
+        return Err("Like already exists".to_string());
+    }
+
+    Ok(ProjectLikeCreatedResponse {
+        project_id: project_id.value().to_string(),
+        user_address: user_address.to_string(),
+    })
+}
+

--- a/backend/src/application/commands/delete_project_like.rs
+++ b/backend/src/application/commands/delete_project_like.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use crate::domain::{
+    entities::projects::ProjectId,
+    repositories::{ProjectLikeRepository, ProjectRepository},
+    value_objects::WalletAddress,
+};
+
+pub async fn delete_project_like(
+    project_repository: Arc<dyn ProjectRepository>,
+    like_repository: Arc<dyn ProjectLikeRepository>,
+    user_address: String,
+    project_id: String,
+) -> Result<(), String> {
+    let user_address = WalletAddress::new(user_address.to_lowercase())
+        .map_err(|e| format!("Invalid wallet address: {}", e))?;
+
+    let uuid = uuid::Uuid::parse_str(&project_id).map_err(|_| "Invalid project id".to_string())?;
+    let project_id = ProjectId::from_uuid(uuid);
+
+    let exists = project_repository
+        .exists(&project_id)
+        .await
+        .map_err(|e| e.to_string())?;
+    if !exists {
+        return Err("Project not found".to_string());
+    }
+
+    let deleted = like_repository
+        .delete(&project_id, &user_address)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if !deleted {
+        return Err("Like not found".to_string());
+    }
+
+    Ok(())
+}
+

--- a/backend/src/application/commands/mod.rs
+++ b/backend/src/application/commands/mod.rs
@@ -1,5 +1,7 @@
 pub mod create_profile;
+pub mod create_project_like;
 pub mod create_project;
+pub mod delete_project_like;
 pub mod delete_project;
 pub mod login;
 pub mod update_profile;

--- a/backend/src/application/dtos/like_dtos.rs
+++ b/backend/src/application/dtos/like_dtos.rs
@@ -1,0 +1,21 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectLikeResponse {
+    pub user_address: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectLikesResponse {
+    pub project_id: String,
+    pub total: i64,
+    pub likes: Vec<ProjectLikeResponse>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectLikeCreatedResponse {
+    pub project_id: String,
+    pub user_address: String,
+}

--- a/backend/src/application/dtos/mod.rs
+++ b/backend/src/application/dtos/mod.rs
@@ -1,6 +1,8 @@
 pub mod auth_dtos;
+pub mod like_dtos;
 pub mod profile_dtos;
 pub mod project_dtos;
 pub use auth_dtos::*;
+pub use like_dtos::*;
 pub use profile_dtos::*;
 pub use project_dtos::*;

--- a/backend/src/application/queries/get_project_likes.rs
+++ b/backend/src/application/queries/get_project_likes.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use crate::{
+    application::dtos::like_dtos::{ProjectLikeResponse, ProjectLikesResponse},
+    domain::{
+        entities::projects::ProjectId,
+        repositories::{ProjectLikeRepository, ProjectRepository},
+    },
+};
+
+pub async fn get_project_likes(
+    project_repository: Arc<dyn ProjectRepository>,
+    like_repository: Arc<dyn ProjectLikeRepository>,
+    project_id: String,
+    limit: Option<i64>,
+    offset: Option<i64>,
+) -> Result<ProjectLikesResponse, String> {
+    let uuid = uuid::Uuid::parse_str(&project_id).map_err(|_| "Invalid project id".to_string())?;
+    let project_id = ProjectId::from_uuid(uuid);
+
+    let exists = project_repository
+        .exists(&project_id)
+        .await
+        .map_err(|e| e.to_string())?;
+    if !exists {
+        return Err("Project not found".to_string());
+    }
+
+    let limit = limit.unwrap_or(50).clamp(1, 100);
+    let offset = offset.unwrap_or(0).max(0);
+
+    let total = like_repository
+        .count_by_project(&project_id)
+        .await
+        .map_err(|e| e.to_string())?;
+    let likes = like_repository
+        .list_by_project(&project_id, limit, offset)
+        .await
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .map(|l| ProjectLikeResponse {
+            user_address: l.user_address.to_string(),
+            created_at: l.created_at,
+        })
+        .collect();
+
+    Ok(ProjectLikesResponse {
+        project_id: project_id.value().to_string(),
+        total,
+        likes,
+    })
+}
+

--- a/backend/src/application/queries/mod.rs
+++ b/backend/src/application/queries/mod.rs
@@ -5,3 +5,4 @@ pub mod get_profile;
 pub mod get_projects_by_creator;
 
 pub mod get_project;
+pub mod get_project_likes;

--- a/backend/src/domain/entities/mod.rs
+++ b/backend/src/domain/entities/mod.rs
@@ -1,5 +1,6 @@
 pub mod profile;
 pub mod projects;
+pub mod project_like;
 
 pub use profile::Profile;
 pub use projects::{Project, ProjectId, ProjectStatus};

--- a/backend/src/domain/entities/project_like.rs
+++ b/backend/src/domain/entities/project_like.rs
@@ -1,0 +1,10 @@
+use chrono::{DateTime, Utc};
+
+use crate::domain::{entities::projects::ProjectId, value_objects::WalletAddress};
+
+#[derive(Debug, Clone)]
+pub struct ProjectLike {
+    pub project_id: ProjectId,
+    pub user_address: WalletAddress,
+    pub created_at: DateTime<Utc>,
+}

--- a/backend/src/domain/repositories/mod.rs
+++ b/backend/src/domain/repositories/mod.rs
@@ -1,5 +1,7 @@
 pub mod profile_repository;
+pub mod project_like_repository;
 pub mod project_repository;
 
 pub use profile_repository::ProfileRepository;
+pub use project_like_repository::ProjectLikeRepository;
 pub use project_repository::ProjectRepository;

--- a/backend/src/domain/repositories/project_like_repository.rs
+++ b/backend/src/domain/repositories/project_like_repository.rs
@@ -1,0 +1,39 @@
+use async_trait::async_trait;
+
+use crate::domain::{
+    entities::{project_like::ProjectLike, projects::ProjectId},
+    value_objects::WalletAddress,
+};
+
+#[async_trait]
+pub trait ProjectLikeRepository: Send + Sync {
+    async fn create(
+        &self,
+        project_id: &ProjectId,
+        user_address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>>;
+
+    async fn delete(
+        &self,
+        project_id: &ProjectId,
+        user_address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>>;
+
+    async fn list_by_project(
+        &self,
+        project_id: &ProjectId,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ProjectLike>, Box<dyn std::error::Error>>;
+
+    async fn count_by_project(
+        &self,
+        project_id: &ProjectId,
+    ) -> Result<i64, Box<dyn std::error::Error>>;
+
+    async fn exists(
+        &self,
+        project_id: &ProjectId,
+        user_address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>>;
+}

--- a/backend/src/infrastructure/repositories/mod.rs
+++ b/backend/src/infrastructure/repositories/mod.rs
@@ -1,5 +1,7 @@
 pub mod postgres_profile_repository;
+pub mod postgres_project_like_repository;
 pub mod postgres_project_repository;
 
 pub use postgres_profile_repository::PostgresProfileRepository;
+pub use postgres_project_like_repository::PostgresProjectLikeRepository;
 pub use postgres_project_repository::PostgresProjectRepository;

--- a/backend/src/infrastructure/repositories/postgres_project_like_repository.rs
+++ b/backend/src/infrastructure/repositories/postgres_project_like_repository.rs
@@ -1,0 +1,140 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::domain::{
+    entities::{
+        project_like::ProjectLike,
+        projects::ProjectId,
+    },
+    repositories::project_like_repository::ProjectLikeRepository,
+    value_objects::WalletAddress,
+};
+
+#[derive(Clone)]
+pub struct PostgresProjectLikeRepository {
+    pool: PgPool,
+}
+
+impl PostgresProjectLikeRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ProjectLikeRepository for PostgresProjectLikeRepository {
+    async fn create(
+        &self,
+        project_id: &ProjectId,
+        user_address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO project_likes (project_id, user_address)
+            VALUES ($1, $2)
+            ON CONFLICT (project_id, user_address) DO NOTHING
+            "#,
+        )
+        .bind(project_id.value())
+        .bind(user_address.as_str())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
+    async fn delete(
+        &self,
+        project_id: &ProjectId,
+        user_address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM project_likes
+            WHERE project_id = $1 AND user_address = $2
+            "#,
+        )
+        .bind(project_id.value())
+        .bind(user_address.as_str())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
+    async fn list_by_project(
+        &self,
+        project_id: &ProjectId,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ProjectLike>, Box<dyn std::error::Error>> {
+        let rows = sqlx::query_as::<_, (Uuid, String, DateTime<Utc>)>(
+            r#"
+            SELECT project_id, user_address, created_at
+            FROM project_likes
+            WHERE project_id = $1
+            ORDER BY created_at DESC
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(project_id.value())
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(project_id, user_address, created_at)| ProjectLike {
+                project_id: ProjectId::from_uuid(project_id),
+                user_address: WalletAddress(user_address),
+                created_at,
+            })
+            .collect())
+    }
+
+    async fn count_by_project(
+        &self,
+        project_id: &ProjectId,
+    ) -> Result<i64, Box<dyn std::error::Error>> {
+        let count = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*)
+            FROM project_likes
+            WHERE project_id = $1
+            "#,
+        )
+        .bind(project_id.value())
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+
+        Ok(count)
+    }
+
+    async fn exists(
+        &self,
+        project_id: &ProjectId,
+        user_address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let exists = sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS(
+                SELECT 1 FROM project_likes WHERE project_id = $1 AND user_address = $2
+            )
+            "#,
+        )
+        .bind(project_id.value())
+        .bind(user_address.as_str())
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+
+        Ok(exists)
+    }
+}

--- a/backend/tests/project_likes_api_tests.rs
+++ b/backend/tests/project_likes_api_tests.rs
@@ -1,0 +1,300 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use guild_backend::{
+    domain::{
+        entities::{
+            profile::Profile,
+            project_like::ProjectLike,
+            projects::{Project, ProjectId, ProjectStatus},
+        },
+        repositories::{ProfileRepository, ProjectLikeRepository, ProjectRepository},
+        services::auth_service::{AuthChallenge, AuthResult, AuthService},
+        value_objects::WalletAddress,
+    },
+    presentation::api::{test_api, AppState},
+};
+use std::{collections::HashSet, sync::Arc};
+use tower::ServiceExt;
+
+#[derive(Default)]
+struct FakeProfileRepo;
+
+#[async_trait::async_trait]
+impl ProfileRepository for FakeProfileRepo {
+    async fn find_by_address(
+        &self,
+        _address: &WalletAddress,
+    ) -> Result<Option<Profile>, Box<dyn std::error::Error>> {
+        Ok(None)
+    }
+
+    async fn find_all(&self) -> Result<Vec<Profile>, Box<dyn std::error::Error>> {
+        Ok(vec![])
+    }
+
+    async fn create(&self, _profile: &Profile) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+
+    async fn update(&self, _profile: &Profile) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+
+    async fn delete(&self, _address: &WalletAddress) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+
+    async fn find_by_github_login(
+        &self,
+        _github_login: &str,
+    ) -> Result<Option<Profile>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(None)
+    }
+
+    async fn find_by_twitter_handle(
+        &self,
+        _twitter_handle: &str,
+    ) -> Result<Option<Profile>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(None)
+    }
+
+    async fn get_login_nonce_by_wallet_address(
+        &self,
+        _address: &WalletAddress,
+    ) -> Result<Option<i64>, Box<dyn std::error::Error>> {
+        Ok(None)
+    }
+
+    async fn increment_login_nonce(
+        &self,
+        _address: &WalletAddress,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct FakeAuthService;
+
+#[async_trait::async_trait]
+impl AuthService for FakeAuthService {
+    async fn verify_signature(
+        &self,
+        _challenge: &AuthChallenge,
+        _signature: &str,
+    ) -> Result<Option<AuthResult>, Box<dyn std::error::Error>> {
+        Ok(None)
+    }
+}
+
+#[derive(Default)]
+struct FakeProjectRepo {
+    projects: std::sync::Mutex<HashSet<ProjectId>>,
+}
+
+#[async_trait::async_trait]
+impl ProjectRepository for FakeProjectRepo {
+    async fn create(&self, project: &Project) -> Result<(), Box<dyn std::error::Error>> {
+        self.projects.lock().unwrap().insert(project.id);
+        Ok(())
+    }
+
+    async fn find_by_id(
+        &self,
+        id: &ProjectId,
+    ) -> Result<Option<Project>, Box<dyn std::error::Error>> {
+        let exists = self.projects.lock().unwrap().contains(id);
+        Ok(exists.then(|| Project::new(
+            "x".into(),
+            "y".into(),
+            ProjectStatus::Proposal,
+            WalletAddress::new("0x0000000000000000000000000000000000000000".into()).unwrap(),
+        )))
+    }
+
+    async fn find_all(
+        &self,
+        _status: Option<ProjectStatus>,
+        _creator: Option<&WalletAddress>,
+        _limit: Option<i64>,
+        _offset: Option<i64>,
+    ) -> Result<Vec<Project>, Box<dyn std::error::Error>> {
+        Ok(vec![])
+    }
+
+    async fn find_by_creator(
+        &self,
+        _creator: &WalletAddress,
+    ) -> Result<Vec<Project>, Box<dyn std::error::Error>> {
+        Ok(vec![])
+    }
+
+    async fn update(&self, _project: &Project) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+
+    async fn delete(&self, id: &ProjectId) -> Result<(), Box<dyn std::error::Error>> {
+        self.projects.lock().unwrap().remove(id);
+        Ok(())
+    }
+
+    async fn exists(&self, id: &ProjectId) -> Result<bool, Box<dyn std::error::Error>> {
+        Ok(self.projects.lock().unwrap().contains(id))
+    }
+
+    async fn profile_exists(
+        &self,
+        _address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        Ok(true)
+    }
+}
+
+#[derive(Default)]
+struct FakeLikeRepo {
+    likes: std::sync::Mutex<HashSet<(ProjectId, String)>>,
+}
+
+#[async_trait::async_trait]
+impl ProjectLikeRepository for FakeLikeRepo {
+    async fn create(
+        &self,
+        project_id: &ProjectId,
+        user_address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        Ok(self
+            .likes
+            .lock()
+            .unwrap()
+            .insert((*project_id, user_address.as_str().to_string())))
+    }
+
+    async fn delete(
+        &self,
+        project_id: &ProjectId,
+        user_address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        Ok(self
+            .likes
+            .lock()
+            .unwrap()
+            .remove(&(*project_id, user_address.as_str().to_string())))
+    }
+
+    async fn list_by_project(
+        &self,
+        project_id: &ProjectId,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ProjectLike>, Box<dyn std::error::Error>> {
+        let mut list: Vec<ProjectLike> = self
+            .likes
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(pid, _)| pid == project_id)
+            .skip(offset as usize)
+            .take(limit as usize)
+            .map(|(pid, addr)| ProjectLike {
+                project_id: *pid,
+                user_address: WalletAddress(addr.clone()),
+                created_at: chrono::Utc::now(),
+            })
+            .collect();
+        list.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(list)
+    }
+
+    async fn count_by_project(
+        &self,
+        project_id: &ProjectId,
+    ) -> Result<i64, Box<dyn std::error::Error>> {
+        Ok(self
+            .likes
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(pid, _)| pid == project_id)
+            .count() as i64)
+    }
+
+    async fn exists(
+        &self,
+        project_id: &ProjectId,
+        user_address: &WalletAddress,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        Ok(self.likes.lock().unwrap().contains(&(
+            *project_id,
+            user_address.as_str().to_string(),
+        )))
+    }
+}
+
+#[tokio::test]
+async fn likes_crd_flow_works() {
+    let project_id = ProjectId::new();
+
+    let project_repo = Arc::new(FakeProjectRepo::default());
+    project_repo.projects.lock().unwrap().insert(project_id);
+
+    let app = test_api(AppState {
+        profile_repository: Arc::new(FakeProfileRepo::default()),
+        project_repository: project_repo,
+        project_like_repository: Arc::new(FakeLikeRepo::default()),
+        auth_service: Arc::new(FakeAuthService::default()),
+    });
+
+    let project_id_str = project_id.value().to_string();
+
+    // Create like
+    let create_req = Request::builder()
+        .method("POST")
+        .uri(format!("/projects/{}/likes", project_id_str))
+        .header("x-eth-address", "0xABcdefabcdefabcdefabcdefabcdefabcdefabcdEF")
+        .body(Body::empty())
+        .unwrap();
+    let create_resp = app.clone().oneshot(create_req).await.unwrap();
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+
+    // Duplicate like -> conflict
+    let dup_req = Request::builder()
+        .method("POST")
+        .uri(format!("/projects/{}/likes", project_id_str))
+        .header("x-eth-address", "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef")
+        .body(Body::empty())
+        .unwrap();
+    let dup_resp = app.clone().oneshot(dup_req).await.unwrap();
+    assert_eq!(dup_resp.status(), StatusCode::CONFLICT);
+
+    // Read likes
+    let read_req = Request::builder()
+        .method("GET")
+        .uri(format!("/projects/{}/likes", project_id_str))
+        .body(Body::empty())
+        .unwrap();
+    let read_resp = app.clone().oneshot(read_req).await.unwrap();
+    assert_eq!(read_resp.status(), StatusCode::OK);
+
+    // Delete like
+    let del_req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/projects/{}/likes", project_id_str))
+        .header("x-eth-address", "0xABCDEFabcdefabcdefabcdefabcdefabcdefabcdef")
+        .body(Body::empty())
+        .unwrap();
+    let del_resp = app.clone().oneshot(del_req).await.unwrap();
+    assert_eq!(del_resp.status(), StatusCode::NO_CONTENT);
+
+    // Delete again -> not found
+    let del2_req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/projects/{}/likes", project_id_str))
+        .header("x-eth-address", "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef")
+        .body(Body::empty())
+        .unwrap();
+    let del2_resp = app.oneshot(del2_req).await.unwrap();
+    assert_eq!(del2_resp.status(), StatusCode::NOT_FOUND);
+}
+


### PR DESCRIPTION
## Summary

Adds backend support for “likes” on projects. Any authenticated user (JWT via existing `Authorization: Bearer ...` handling) can like/unlike a project, with a hard guarantee of **one like per user per project**.

## What changed

### Database
- Added `project_likes` table via `backend/migrations/006_create_project_likes_table.sql`
  - Columns: `project_id (UUID)`, `user_address (VARCHAR(42))`, `created_at (timestamptz)`
  - Primary key: `(project_id, user_address)` to enforce one-like-per-user-per-project
  - Foreign key: `project_id -> projects(id)` with `ON DELETE CASCADE`
  - Indexes on `project_id` and `user_address`

### Domain / Infrastructure
- New repository abstraction: `ProjectLikeRepository`
- New Postgres implementation: `PostgresProjectLikeRepository`

### API
Routes added:
- `POST /projects/:id/likes` (protected)  
  - Creates a like for the authenticated user
  - Returns `201 Created`
  - Returns `409 Conflict` if the like already exists
  - Returns `404 Not Found` if the project doesn’t exist
- `DELETE /projects/:id/likes` (protected)  
  - Removes the authenticated user’s like
  - Returns `204 No Content`
  - Returns `404 Not Found` if the like doesn’t exist (or project doesn’t exist)
- `GET /projects/:id/likes?limit=&offset=` (public)  
  - Lists likes for a project (paginated)
  - Returns `{ project_id, total, likes: [{ user_address, created_at }, ...] }`

## Behavior / Constraints

- Idempotency:
  - `POST` is **not** idempotent: duplicate like attempts return `409`
  - `DELETE` is **not** idempotent: deleting a non-existent like returns `404`
- Project existence is validated for all three endpoints.
- User identity comes from the existing auth middleware (`VerifiedWallet`), including JWT support already implemented in the codebase.

## Files of note

- Migration: `backend/migrations/006_create_project_likes_table.sql`
- API wiring: `backend/src/presentation/api.rs`
- Handlers: `backend/src/presentation/handlers.rs`
- DTOs: `backend/src/application/dtos/like_dtos.rs`
- Commands/Query:
  - `backend/src/application/commands/create_project_like.rs`
  - `backend/src/application/commands/delete_project_like.rs`
  - `backend/src/application/queries/get_project_likes.rs`
- Repository + Postgres implementation:
  - `backend/src/domain/repositories/project_like_repository.rs`
  - `backend/src/infrastructure/repositories/postgres_project_like_repository.rs`

## Testing

- Added router-level API tests (no DB required):
  - `backend/tests/project_likes_api_tests.rs` validates the CRD flow and status codes.
- Updated existing Postgres integration tests to **skip cleanly** when Postgres is unavailable:
  - `backend/tests/integration_github_handle.rs`

Run:
- `cd backend`
- `cargo test`

## Notes / Follow-ups

- If we later want “like count” returned on `GET /projects/:id`, we can extend `get_project`/project DTOs to include `likes_total` (and optionally `liked_by_me` when authenticated).
