### PR TITLE
frontend for twitter implemented

### DIFF
--- a/frontend/.astro/settings.json
+++ b/frontend/.astro/settings.json
@@ -1,6 +1,6 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1761559074026
+		"lastUpdateCheck": 1770638442880
 	},
 	"eslint.validate": [
 		"javascript",

--- a/frontend/src/components/profiles/action-buttons/CreateProfileDialog.tsx
+++ b/frontend/src/components/profiles/action-buttons/CreateProfileDialog.tsx
@@ -30,6 +30,7 @@ const formSchema = z.object({
   name: z.string().min(2, { message: "Name must be at least 2 characters." }),
   description: z.string().optional(),
   githubLogin: z.string().optional(),
+  twitterHandle: z.string().optional(),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -50,6 +51,7 @@ export function CreateProfileButton() {
         name: values.name,
         description: values.description || "",
         github_login: values.githubLogin || "",
+        twitter_handle: values.twitterHandle || "",
       },
     });
     await queryClient.invalidateQueries({ queryKey: ["profiles"] });
@@ -110,6 +112,22 @@ export function CreateProfileButton() {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>GitHub Handle</FormLabel>
+                  <FormControl>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-gray-500">@</span>
+                      <Input placeholder="username" {...field} />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="twitterHandle"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Twitter/X Handle</FormLabel>
                   <FormControl>
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-gray-500">@</span>

--- a/frontend/src/components/profiles/action-buttons/EditProfileDialog.tsx
+++ b/frontend/src/components/profiles/action-buttons/EditProfileDialog.tsx
@@ -30,6 +30,7 @@ interface EditProfileDialogProps {
   name?: string;
   description?: string;
   githubLogin?: string;
+  twitterHandle?: string;
   children: React.ReactNode;
 }
 
@@ -37,6 +38,7 @@ const formSchema = z.object({
   name: z.string().min(2, { message: "Name must be at least 2 characters." }),
   description: z.string().optional(),
   githubLogin: z.string().optional(),
+  twitterHandle: z.string().optional(),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -46,6 +48,7 @@ export function EditProfileDialog({
   name,
   description,
   githubLogin,
+  twitterHandle,
   children,
 }: EditProfileDialogProps) {
   const [open, setOpen] = useState(false);
@@ -58,6 +61,7 @@ export function EditProfileDialog({
       name: name || "",
       description: description || "",
       githubLogin: githubLogin || "",
+      twitterHandle: twitterHandle || "",
     },
   });
 
@@ -67,9 +71,10 @@ export function EditProfileDialog({
         name: name || "",
         description: description || "",
         githubLogin: githubLogin || "",
+        twitterHandle: twitterHandle || "",
       });
     }
-  }, [open, name, description, githubLogin, form]);
+  }, [open, name, description, githubLogin, twitterHandle, form]);
 
   const onSubmit = async (values: FormValues) => {
     try {
@@ -78,6 +83,7 @@ export function EditProfileDialog({
           name: values.name,
           description: values.description || "",
           github_login: values.githubLogin || "",
+          twitter_handle: values.twitterHandle || "",
         },
       });
       await queryClient.invalidateQueries({ queryKey: ["profiles"] });
@@ -135,6 +141,22 @@ export function EditProfileDialog({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>GitHub Handle</FormLabel>
+                  <FormControl>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-gray-500">@</span>
+                      <Input placeholder="username" {...field} />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="twitterHandle"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Twitter/X Handle</FormLabel>
                   <FormControl>
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-gray-500">@</span>

--- a/frontend/src/components/profiles/list/ProfileCard.tsx
+++ b/frontend/src/components/profiles/list/ProfileCard.tsx
@@ -20,6 +20,7 @@ interface ProfileCardProps {
   description?: string;
   avatar?: string;
   githubLogin?: string;
+  twitterHandle?: string;
   attestationCount: number;
   attestations: Array<{
     id: string;
@@ -35,6 +36,7 @@ export function ProfileCard({
   description,
   avatar,
   githubLogin,
+  twitterHandle,
   attestationCount,
   attestations,
 }: ProfileCardProps) {
@@ -96,6 +98,7 @@ export function ProfileCard({
             name={name}
             description={description}
             githubLogin={githubLogin}
+            twitterHandle={twitterHandle}
           >
             <Button
               variant="ghost"

--- a/frontend/src/components/profiles/list/ProfilesList.tsx
+++ b/frontend/src/components/profiles/list/ProfilesList.tsx
@@ -22,6 +22,7 @@ export function ProfilesList() {
           name: p.name || "",
           description: p.description || "",
           githubLogin: p.github_login,
+          twitterHandle: p.twitter_handle,
           attestationCount: 0,
           attestations: [],
         }))
@@ -116,6 +117,7 @@ export function ProfilesList() {
                 name={profile.name}
                 description={profile.description}
                 githubLogin={profile.githubLogin}
+                twitterHandle={profile.twitterHandle}
                 attestationCount={profile.attestationCount}
                 attestations={profile.attestations}
               />

--- a/frontend/src/components/profiles/profile-page/ProfileActions.tsx
+++ b/frontend/src/components/profiles/profile-page/ProfileActions.tsx
@@ -10,11 +10,13 @@ export function ProfileActions({
   name,
   description,
   githubLogin,
+  twitterHandle,
 }: {
   address?: string;
   name?: string;
   description?: string;
   githubLogin?: string;
+  twitterHandle?: string;
 }) {
   const { address: connectedAddress } = useAccount();
   const isOwner =
@@ -30,6 +32,7 @@ export function ProfileActions({
           name={name}
           description={description}
           githubLogin={githubLogin}
+          twitterHandle={twitterHandle}
         >
           <Button variant="outline" className="flex items-center gap-2">
             <Edit className="h-4 w-4" /> Edit Profile

--- a/frontend/src/components/profiles/profile-page/ProfileHeader.tsx
+++ b/frontend/src/components/profiles/profile-page/ProfileHeader.tsx
@@ -3,18 +3,21 @@ import { useAccount } from "wagmi";
 import AddressTokenBalance from "@/components/AddressTokenBalance";
 import CopyAddressToClipboard from "@/components/CopyAddressToClipboard";
 import { GithubIcon } from "@/components/ui/GithubIcon";
+import { XIcon } from "@/components/ui/XIcon";
 
 interface ProfileHeaderProps {
   address: string;
   name?: string;
   description?: string;
   githubLogin?: string;
+  twitterHandle?: string;
 }
 
 export function ProfileHeader({
   address,
   name,
   githubLogin,
+  twitterHandle,
 }: ProfileHeaderProps) {
   const displayName = name || (address ? `${address.slice(0, 6)}...${address.slice(-4)}` : "Profile");
   const displayAddress = address ? `${address.slice(0, 6)}...${address.slice(-4)}` : "";
@@ -57,6 +60,19 @@ export function ProfileHeader({
               className="text-sm text-gray-700 hover:text-indigo-600 hover:underline"
             >
               @{githubLogin}
+            </a>
+          </div>
+        )}
+        {twitterHandle && (
+          <div className="flex items-center gap-1.5 mt-1">
+            <XIcon className="h-4 w-4 text-gray-500" />
+            <a
+              href={`https://x.com/${twitterHandle}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-gray-700 hover:text-indigo-600 hover:underline"
+            >
+              @{twitterHandle}
             </a>
           </div>
         )}

--- a/frontend/src/components/profiles/profile-page/ProfileMain.tsx
+++ b/frontend/src/components/profiles/profile-page/ProfileMain.tsx
@@ -24,6 +24,7 @@ export function ProfileMain({ address }: { address: string }) {
         name={profile?.name}
         description={profile?.description}
         githubLogin={profile?.github_login}
+        twitterHandle={profile?.twitter_handle}
       />
       <div className="mt-6">
         <ProfileActions
@@ -31,6 +32,7 @@ export function ProfileMain({ address }: { address: string }) {
           name={profile?.name}
           description={profile?.description}
           githubLogin={profile?.github_login}
+          twitterHandle={profile?.twitter_handle}
         />
       </div>
       <ProfileDescription description={profile?.description} />

--- a/frontend/src/components/ui/XIcon.tsx
+++ b/frontend/src/components/ui/XIcon.tsx
@@ -1,0 +1,16 @@
+interface XIconProps {
+  className?: string;
+}
+
+export function XIcon({ className = "h-4 w-4" }: XIconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}

--- a/frontend/src/lib/constants/profileConstants.ts
+++ b/frontend/src/lib/constants/profileConstants.ts
@@ -6,6 +6,7 @@ export const PROFILES: Profile[] = [
     name: "Alice Developer",
     description: "Full-stack developer passionate about Web3 and Rust",
     githubLogin: "alice-dev",
+    twitterHandle: "alice_dev",
     attestationCount: 5,
     attestations: [
       {
@@ -33,6 +34,7 @@ export const PROFILES: Profile[] = [
     name: "Bob Builder",
     description: "Smart contract developer and DeFi enthusiast",
     githubLogin: "bob-builder",
+    twitterHandle: "bob_builder",
     attestationCount: 3,
     attestations: [
       {
@@ -53,7 +55,8 @@ export const PROFILES: Profile[] = [
     address: "0x5555...7777",
     name: "", 
     description: "", 
-    githubLogin: undefined, 
+    githubLogin: undefined,
+    twitterHandle: undefined, 
     attestationCount: 2,
     attestations: [
       {

--- a/frontend/src/lib/types/api.d.ts
+++ b/frontend/src/lib/types/api.d.ts
@@ -3,6 +3,7 @@ export type CreateProfileInput = {
   description?: string;
   avatar_url?: string;
   github_login?: string;
+  twitter_handle?: string;
 };
 
 export type UpdateProfileInput = {
@@ -10,6 +11,7 @@ export type UpdateProfileInput = {
   description?: string;
   avatar_url?: string;
   github_login?: string;
+  twitter_handle?: string;
 };
 
 export type UpdateProfileResponse = unknown;

--- a/frontend/src/lib/types/profiles.d.ts
+++ b/frontend/src/lib/types/profiles.d.ts
@@ -10,6 +10,7 @@ export type Profile = {
   name: string;
   description: string;
   githubLogin?: string;
+  twitterHandle?: string;
   attestationCount: number;
   attestations: ProfileAttestation[];
 };
@@ -20,6 +21,7 @@ export type ProfileFromAPI = {
   description?: string;
   avatar_url?: string;
   github_login?: string;
+  twitter_handle?: string;
   created_at?: string;
   updated_at?: string;
 };


### PR DESCRIPTION
## Add Twitter/X Handle to Frontend Profiles

Closes #173

### Changes

Adds Twitter/X handle support to the frontend, mirroring the existing GitHub handle UX exactly.

**New file:**
- `src/components/ui/XIcon.tsx` — X (Twitter) SVG icon component

**Type definitions:**
- `src/lib/types/api.d.ts` — Added `twitter_handle` to `CreateProfileInput` and `UpdateProfileInput`
- `src/lib/types/profiles.d.ts` — Added `twitterHandle` to `Profile`, `twitter_handle` to `ProfileFromAPI`

**Display:**
- `ProfileHeader` — Shows X icon + clickable `@handle` link (links to `https://x.com/{handle}`)
- `ProfileMain` / `ProfileActions` — Thread `twitterHandle` prop through component tree

**Forms:**
- `EditProfileDialog` / `CreateProfileDialog` — Added "Twitter/X Handle" form field with `@` prefix, matching GitHub Handle field UX

**List view:**
- `ProfileCard` / `ProfilesList` — Map and forward `twitterHandle` from API response

**Mock data:**
- `profileConstants.ts` — Added sample `twitterHandle` values

### Testing
- Zero TypeScript errors across all modified files
- Same UX pattern as GitHub handles — icon, link, form field with `@` prefix