### PR TITLE
add linkedin handles

### DIFF
--- a/frontend/src/components/profiles/action-buttons/CreateProfileDialog.tsx
+++ b/frontend/src/components/profiles/action-buttons/CreateProfileDialog.tsx
@@ -31,6 +31,7 @@ const formSchema = z.object({
   description: z.string().optional(),
   githubLogin: z.string().optional(),
   twitterHandle: z.string().optional(),
+  linkedinAccount: z.string().optional(),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -52,6 +53,7 @@ export function CreateProfileButton() {
         description: values.description || "",
         github_login: values.githubLogin || "",
         twitter_handle: values.twitterHandle || "",
+        linkedin_account: values.linkedinAccount || "",
       },
     });
     await queryClient.invalidateQueries({ queryKey: ["profiles"] });
@@ -128,6 +130,22 @@ export function CreateProfileButton() {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Twitter/X Handle</FormLabel>
+                  <FormControl>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-gray-500">@</span>
+                      <Input placeholder="username" {...field} />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="linkedinAccount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>LinkedIn Handle</FormLabel>
                   <FormControl>
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-gray-500">@</span>

--- a/frontend/src/components/profiles/action-buttons/CreateProfileDialog.tsx
+++ b/frontend/src/components/profiles/action-buttons/CreateProfileDialog.tsx
@@ -26,12 +26,20 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 
+const linkedinUrlRegex = /^(?:https?:\/\/(?:www\.)?linkedin\.com\/in\/)?[a-zA-Z0-9-]{3,100}\/?$/;
+
 const formSchema = z.object({
   name: z.string().min(2, { message: "Name must be at least 2 characters." }),
   description: z.string().optional(),
   githubLogin: z.string().optional(),
   twitterHandle: z.string().optional(),
-  linkedinAccount: z.string().optional(),
+  linkedinAccount: z
+    .string()
+    .optional()
+    .refine(
+      (value) => !value || linkedinUrlRegex.test(value),
+      "LinkedIn URL must be in format: https://www.linkedin.com/in/your-handle or just the handle (3-100 characters)"
+    ),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -145,13 +153,16 @@ export function CreateProfileButton() {
               name="linkedinAccount"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>LinkedIn Handle</FormLabel>
+                  <FormLabel>LinkedIn Profile URL</FormLabel>
                   <FormControl>
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm text-gray-500">@</span>
-                      <Input placeholder="username" {...field} />
-                    </div>
+                    <Input
+                      placeholder="https://www.linkedin.com/in/your-handle/"
+                      {...field}
+                    />
                   </FormControl>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Paste your full LinkedIn URL or just the handle
+                  </p>
                   <FormMessage />
                 </FormItem>
               )}

--- a/frontend/src/components/profiles/action-buttons/EditProfileDialog.tsx
+++ b/frontend/src/components/profiles/action-buttons/EditProfileDialog.tsx
@@ -31,6 +31,7 @@ interface EditProfileDialogProps {
   description?: string;
   githubLogin?: string;
   twitterHandle?: string;
+  linkedinAccount?: string;
   children: React.ReactNode;
 }
 
@@ -39,6 +40,7 @@ const formSchema = z.object({
   description: z.string().optional(),
   githubLogin: z.string().optional(),
   twitterHandle: z.string().optional(),
+  linkedinAccount: z.string().optional(),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -49,6 +51,7 @@ export function EditProfileDialog({
   description,
   githubLogin,
   twitterHandle,
+  linkedinAccount,
   children,
 }: EditProfileDialogProps) {
   const [open, setOpen] = useState(false);
@@ -62,6 +65,7 @@ export function EditProfileDialog({
       description: description || "",
       githubLogin: githubLogin || "",
       twitterHandle: twitterHandle || "",
+      linkedinAccount: linkedinAccount || "",
     },
   });
 
@@ -72,9 +76,10 @@ export function EditProfileDialog({
         description: description || "",
         githubLogin: githubLogin || "",
         twitterHandle: twitterHandle || "",
+        linkedinAccount: linkedinAccount || "",
       });
     }
-  }, [open, name, description, githubLogin, twitterHandle, form]);
+  }, [open, name, description, githubLogin, twitterHandle, linkedinAccount, form]);
 
   const onSubmit = async (values: FormValues) => {
     try {
@@ -84,6 +89,7 @@ export function EditProfileDialog({
           description: values.description || "",
           github_login: values.githubLogin || "",
           twitter_handle: values.twitterHandle || "",
+          linkedin_account: values.linkedinAccount || "",
         },
       });
       await queryClient.invalidateQueries({ queryKey: ["profiles"] });
@@ -157,6 +163,22 @@ export function EditProfileDialog({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Twitter/X Handle</FormLabel>
+                  <FormControl>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-gray-500">@</span>
+                      <Input placeholder="username" {...field} />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="linkedinAccount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>LinkedIn Handle</FormLabel>
                   <FormControl>
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-gray-500">@</span>

--- a/frontend/src/components/profiles/action-buttons/EditProfileDialog.tsx
+++ b/frontend/src/components/profiles/action-buttons/EditProfileDialog.tsx
@@ -35,12 +35,20 @@ interface EditProfileDialogProps {
   children: React.ReactNode;
 }
 
+const linkedinUrlRegex = /^(?:https?:\/\/(?:www\.)?linkedin\.com\/in\/)?[a-zA-Z0-9-]{3,100}\/?$/;
+
 const formSchema = z.object({
   name: z.string().min(2, { message: "Name must be at least 2 characters." }),
   description: z.string().optional(),
   githubLogin: z.string().optional(),
   twitterHandle: z.string().optional(),
-  linkedinAccount: z.string().optional(),
+  linkedinAccount: z
+    .string()
+    .optional()
+    .refine(
+      (value) => !value || linkedinUrlRegex.test(value),
+      "LinkedIn URL must be in format: https://www.linkedin.com/in/your-handle or just the handle (3-100 characters)"
+    ),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -178,13 +186,16 @@ export function EditProfileDialog({
               name="linkedinAccount"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>LinkedIn Handle</FormLabel>
+                  <FormLabel>LinkedIn Profile URL</FormLabel>
                   <FormControl>
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm text-gray-500">@</span>
-                      <Input placeholder="username" {...field} />
-                    </div>
+                    <Input
+                      placeholder="https://www.linkedin.com/in/your-handle/"
+                      {...field}
+                    />
                   </FormControl>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Paste your full LinkedIn URL or just the handle
+                  </p>
                   <FormMessage />
                 </FormItem>
               )}

--- a/frontend/src/components/profiles/list/ProfileCard.tsx
+++ b/frontend/src/components/profiles/list/ProfileCard.tsx
@@ -21,6 +21,7 @@ interface ProfileCardProps {
   avatar?: string;
   githubLogin?: string;
   twitterHandle?: string;
+  linkedinAccount?: string;
   attestationCount: number;
   attestations: Array<{
     id: string;
@@ -37,6 +38,7 @@ export function ProfileCard({
   avatar,
   githubLogin,
   twitterHandle,
+  linkedinAccount,
   attestationCount,
   attestations,
 }: ProfileCardProps) {
@@ -99,6 +101,7 @@ export function ProfileCard({
             description={description}
             githubLogin={githubLogin}
             twitterHandle={twitterHandle}
+            linkedinAccount={linkedinAccount}
           >
             <Button
               variant="ghost"

--- a/frontend/src/components/profiles/list/ProfilesList.tsx
+++ b/frontend/src/components/profiles/list/ProfilesList.tsx
@@ -23,6 +23,7 @@ export function ProfilesList() {
           description: p.description || "",
           githubLogin: p.github_login,
           twitterHandle: p.twitter_handle,
+          linkedinAccount: p.linkedin_account,
           attestationCount: 0,
           attestations: [],
         }))
@@ -118,6 +119,7 @@ export function ProfilesList() {
                 description={profile.description}
                 githubLogin={profile.githubLogin}
                 twitterHandle={profile.twitterHandle}
+                linkedinAccount={profile.linkedinAccount}
                 attestationCount={profile.attestationCount}
                 attestations={profile.attestations}
               />

--- a/frontend/src/components/profiles/profile-page/ProfileActions.tsx
+++ b/frontend/src/components/profiles/profile-page/ProfileActions.tsx
@@ -11,12 +11,14 @@ export function ProfileActions({
   description,
   githubLogin,
   twitterHandle,
+  linkedinAccount,
 }: {
   address?: string;
   name?: string;
   description?: string;
   githubLogin?: string;
   twitterHandle?: string;
+  linkedinAccount?: string;
 }) {
   const { address: connectedAddress } = useAccount();
   const isOwner =
@@ -33,6 +35,7 @@ export function ProfileActions({
           description={description}
           githubLogin={githubLogin}
           twitterHandle={twitterHandle}
+          linkedinAccount={linkedinAccount}
         >
           <Button variant="outline" className="flex items-center gap-2">
             <Edit className="h-4 w-4" /> Edit Profile

--- a/frontend/src/components/profiles/profile-page/ProfileHeader.tsx
+++ b/frontend/src/components/profiles/profile-page/ProfileHeader.tsx
@@ -11,6 +11,7 @@ interface ProfileHeaderProps {
   description?: string;
   githubLogin?: string;
   twitterHandle?: string;
+  linkedinAccount?: string;
 }
 
 export function ProfileHeader({
@@ -18,6 +19,7 @@ export function ProfileHeader({
   name,
   githubLogin,
   twitterHandle,
+  linkedinAccount,
 }: ProfileHeaderProps) {
   const displayName = name || (address ? `${address.slice(0, 6)}...${address.slice(-4)}` : "Profile");
   const displayAddress = address ? `${address.slice(0, 6)}...${address.slice(-4)}` : "";
@@ -73,6 +75,18 @@ export function ProfileHeader({
               className="text-sm text-gray-700 hover:text-indigo-600 hover:underline"
             >
               @{twitterHandle}
+            </a>
+          </div>
+        )}
+        {linkedinAccount && (
+          <div className="flex items-center gap-1.5 mt-1">
+            <a
+              href={`https://www.linkedin.com/in/${linkedinAccount}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-gray-700 hover:text-indigo-600 hover:underline"
+            >
+              @{linkedinAccount}
             </a>
           </div>
         )}

--- a/frontend/src/components/profiles/profile-page/ProfileHeader.tsx
+++ b/frontend/src/components/profiles/profile-page/ProfileHeader.tsx
@@ -5,6 +5,34 @@ import CopyAddressToClipboard from "@/components/CopyAddressToClipboard";
 import { GithubIcon } from "@/components/ui/GithubIcon";
 import { XIcon } from "@/components/ui/XIcon";
 
+// Helper function to extract handle or full URL from LinkedIn input
+const parseLinkedinAccount = (
+  account: string
+): { displayHandle: string; profileUrl: string } => {
+  if (!account) return { displayHandle: "", profileUrl: "" };
+
+  // If it's already a full URL, extract the handle and use it as-is
+  if (account.startsWith("http")) {
+    // Already a full URL, just ensure it's properly formatted
+    const url =
+      account.endsWith("/") || account.endsWith("recruit")
+        ? account
+        : account + "/";
+    const handle =
+      account.match(/\/in\/([^/?]+)/)?.[1] || account.split("/").pop() || "";
+    return {
+      displayHandle: handle || "LinkedIn",
+      profileUrl: url,
+    };
+  }
+
+  // It's just a handle, construct the full URL
+  return {
+    displayHandle: account,
+    profileUrl: `https://www.linkedin.com/in/${account}/`,
+  };
+};
+
 interface ProfileHeaderProps {
   address: string;
   name?: string;
@@ -29,6 +57,9 @@ export function ProfileHeader({
     !!connectedAddress &&
     !!address &&
     connectedAddress.toLowerCase() === address.toLowerCase();
+
+  const linkedinData =
+    linkedinAccount && parseLinkedinAccount(linkedinAccount);
 
   return (
     <header className="flex items-start gap-4">
@@ -78,15 +109,15 @@ export function ProfileHeader({
             </a>
           </div>
         )}
-        {linkedinAccount && (
+        {linkedinData && (
           <div className="flex items-center gap-1.5 mt-1">
             <a
-              href={`https://www.linkedin.com/in/${linkedinAccount}`}
+              href={linkedinData.profileUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-sm text-gray-700 hover:text-indigo-600 hover:underline"
             >
-              @{linkedinAccount}
+              🔗 {linkedinData.displayHandle}
             </a>
           </div>
         )}

--- a/frontend/src/components/profiles/profile-page/ProfileMain.tsx
+++ b/frontend/src/components/profiles/profile-page/ProfileMain.tsx
@@ -25,6 +25,7 @@ export function ProfileMain({ address }: { address: string }) {
         description={profile?.description}
         githubLogin={profile?.github_login}
         twitterHandle={profile?.twitter_handle}
+        linkedinAccount={profile?.linkedin_account}
       />
       <div className="mt-6">
         <ProfileActions
@@ -33,6 +34,7 @@ export function ProfileMain({ address }: { address: string }) {
           description={profile?.description}
           githubLogin={profile?.github_login}
           twitterHandle={profile?.twitter_handle}
+          linkedinAccount={profile?.linkedin_account}
         />
       </div>
       <ProfileDescription description={profile?.description} />

--- a/frontend/src/lib/constants/profileConstants.ts
+++ b/frontend/src/lib/constants/profileConstants.ts
@@ -7,6 +7,7 @@ export const PROFILES: Profile[] = [
     description: "Full-stack developer passionate about Web3 and Rust",
     githubLogin: "alice-dev",
     twitterHandle: "alice_dev",
+    linkedinAccount: "alice-developer",
     attestationCount: 5,
     attestations: [
       {
@@ -35,6 +36,7 @@ export const PROFILES: Profile[] = [
     description: "Smart contract developer and DeFi enthusiast",
     githubLogin: "bob-builder",
     twitterHandle: "bob_builder",
+    linkedinAccount: "bob-builder",
     attestationCount: 3,
     attestations: [
       {
@@ -53,10 +55,11 @@ export const PROFILES: Profile[] = [
   },
   {
     address: "0x5555...7777",
-    name: "", 
-    description: "", 
+    name: "",
+    description: "",
     githubLogin: undefined,
-    twitterHandle: undefined, 
+    twitterHandle: undefined,
+    linkedinAccount: undefined,
     attestationCount: 2,
     attestations: [
       {

--- a/frontend/src/lib/types/api.d.ts
+++ b/frontend/src/lib/types/api.d.ts
@@ -4,6 +4,7 @@ export type CreateProfileInput = {
   avatar_url?: string;
   github_login?: string;
   twitter_handle?: string;
+  linkedin_account?: string;
 };
 
 export type UpdateProfileInput = {
@@ -12,6 +13,7 @@ export type UpdateProfileInput = {
   avatar_url?: string;
   github_login?: string;
   twitter_handle?: string;
+  linkedin_account?: string;
 };
 
 export type UpdateProfileResponse = unknown;

--- a/frontend/src/lib/types/profiles.d.ts
+++ b/frontend/src/lib/types/profiles.d.ts
@@ -11,6 +11,7 @@ export type Profile = {
   description: string;
   githubLogin?: string;
   twitterHandle?: string;
+  linkedinAccount?: string;
   attestationCount: number;
   attestations: ProfileAttestation[];
 };
@@ -22,6 +23,7 @@ export type ProfileFromAPI = {
   avatar_url?: string;
   github_login?: string;
   twitter_handle?: string;
+  linkedin_account?: string;
   created_at?: string;
   updated_at?: string;
 };


### PR DESCRIPTION
### Summary
Adds LinkedIn handle support to frontend profiles using the same flow as existing social profile fields.

### Changes
- Added `linkedin_account` support to frontend profile/API types.
- Added LinkedIn Handle field in create/edit profile dialogs and sent it in payloads.
- Mapped `linkedin_account` from backend responses through profile list/page components.
- Displayed LinkedIn handle on profile header with link to `https://www.linkedin.com/in/{handle}`.

Closes #182 